### PR TITLE
grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Another powerful offering from Angular is the integrated event system. This allo
 
 All events can be published on our `$scope` or `$rootScope` objects. Why do we use events? Well, communication between controllers in two different aspects of the application can become quite hard - how can our controllers notify each other of updates? Or imagine if we receive data in a service and that data gets updated - how can we notify the controllers that there is new data to consume. This is where events come in! 
 
-Angular offers us two ways of publishing events - either up or down. Up will go all the way from the current scope to our root scope, and down will go down from our current scope into it's children scopes, and all it's children's scopes, and so on and so forth.
+Angular offers us two ways of publishing events - either up or down. Up will go all the way from the current scope to our root scope, and down will go down from our current scope into its children's scopes, and all their children's scopes, and so on and so forth.
 
 Child scopes are a bit tricky to understand - but don't worry, they're really simple! Let's imagine where we start our app - `ng-app`. This is our `$rootScope`. Then, we use `ng-controller` or a directive inside `ng-app`. This will create another scope, inside of our root scope. Then, if we were to use a directive inside of them, we'd get a child scope inside their scope. Whenever we use a directive (`ng-controller`, `ng-repeat`, custom directives etc) that create their own scope, they're made in their parents scopes.
 
-To publish events downwards, we use `$scope.$broadcast`. To publish event upwards, we use `$scope.$emit`.
+To publish events downwards, we use `$scope.$broadcast`. To publish events upwards, we use `$scope.$emit`.
 
 The first argument we pass through to these functions is the name of the event. This is what we would then specify when we want to listen for the event. We could have a message being sent and then received, so we'd generally namespace these into `message` and then the action - such as `message:sent` and `message:received`.
 
-The second argument we pass through is data. This can then be picked up by the subscriber. For instance, we might want to publish an event when the user sends a message - we can send the message data through with the event too, and subscribe to it in a directive that then displays the message.
+The second argument we pass through is data. This can then be picked up by the subscriber. For instance, we might want to publish an event when the user sends a message - we can send the message data through with the event too and subscribe to it in a directive that then displays the message.
 
 Examples of this are:
 
@@ -35,7 +35,7 @@ $scope.$broadcast('aDifferentEvent', 3949324); // we can pass through any data
 
 ## Subscribing to events
 
-We can then use a function named `$on` to subscribe to these events. We pass through a callback too, which retrieves the data (if there is any) too.
+We can then use a function named `$on` to subscribe to these events. We pass through a callback too, which retrieves the data (if there is any).
 
 We can subscribe to the events above like so:
 


### PR DESCRIPTION
- "into it's children scopes, and all it's children's scopes" --> "into its children's scopes, and all their children's scopes"
- event --> events
- fix comma splice
- excise excess 'too'
